### PR TITLE
Initialize CHATHAM.md for MCP approval and ARB review

### DIFF
--- a/CHATHAM.md
+++ b/CHATHAM.md
@@ -1,0 +1,105 @@
+# Chatham Organization - MCP Security Review and Approval
+
+This document outlines the security review and approval status for the `playwright-mcp` repository for use within the Chatham organization.
+
+## Review Details
+
+*   **Repository:** `Chatham/playwright-mcp`
+*   **Commit SHA at Review:** 0df6d7a441c8fedfe449c115f371e4edd411a865
+*   **Latest Review Date:** June 11, 2025
+*   **Reviewers/Approvers:**
+    *   Reviewer: Paul Hiatt
+    *   Approver: Jay Lenti
+
+## Security Checks
+
+| Check                                                                 | Status      | Notes                                     |
+| :-------------------------------------------------------------------- | :---------- | :---------------------------------------- |
+| **SECURITY.md File**                                                  |             |                                           |
+|   - Existence of `SECURITY.md`                                        | [x] Done    | File exists with Microsoft security template |
+|   - `SECURITY.md` contains clear vulnerability reporting instructions | [x] Done    | Instructions to report to MSRC provided     |
+|   - `SECURITY.md` outlines supported versions & update policy         | [x] Done    | Added supported versions section            |
+| **Dependency Management**                                             |             |                                           |
+|   - No known critical vulnerabilities in direct dependencies          | [x] Done    | Checked via `npm audit`, found 0 vulnerabilities |
+|   - Dependencies are pinned to specific versions                      | [x] Done    | All dependencies use specific version numbers   |
+|   - Plan for monitoring and updating dependencies                     | [x] Done    | Created DEPENDENCIES.md with update policy      |
+| **Code Review**                                                       |             |                                           |
+|   - Sensitive data handling (no hardcoded secrets, PII, etc.)         | [x] Done    | No hardcoded secrets found in source code         |
+|   - Input validation and sanitization                                 | [x] Done    | Input validation present in config parsing        |
+|   - Secure use of external commands/processes                         | [x] Done    | No direct command execution from user input found |
+|   - Error handling and logging (no sensitive info in logs)            | [x] Done    | Error handling follows best practices            |
+| **Build & Release Process**                                           |             |                                           |
+|   - Build process is reproducible                                     | [x] Done    | Build process uses TypeScript compiler with clean step |
+|   - Release artifacts are securely stored                             | [x] N/A     | Primarily used via local clone         |
+| **Documentation**                                                     |             |                                           |
+|   - Clear installation and usage instructions                         | [x] Done    | README.md contains detailed installation steps |
+|   - Documentation on security features or considerations              | [x] Done    | Created SECURITY-FEATURES.md with detailed docs |
+| **Threat Modeling**                                                   |             |                                           |
+|   - Potential threats and attack vectors identified                   | [x] Done    | Input validation, sanitization, error handling |
+|   - Mitigations for identified threats in place                       | [x] Done    | Proper use of Zod for schema validation       |
+| **Licensing**                                                         |             |                                           |
+|   - `LICENSE` file exists                                             | [x] Done    | Apache License 2.0 included                   |
+|   - License is compatible with organizational policies                | [x] Done    | Apache 2.0 is business-friendly open source license |
+
+*Mark `[x]` for completed items.*
+
+## Installation and Usage of Approved Version
+
+To ensure you are using the reviewed and approved version of this tool, follow these installation steps:
+
+1.  **Clone the Repository:**
+    ```bash
+    git clone [repository_url] playwright-mcp
+    cd playwright-mcp
+    ```
+    *(Replace `[repository_url]` with the actual URL to the repository if it's hosted, or ensure you have the correct local copy.)*
+
+2.  **Checkout the Approved Commit:**
+    ```bash
+    git checkout 0df6d7a441c8fedfe449c115f371e4edd411a865
+    ```
+
+3.  **Install Dependencies:**
+    ```bash
+    npm install
+    ```
+
+4.  **Build the Project:**
+    ```bash
+    npm run clean && npm run build
+    ```
+
+5.  **Configure in VS Code (or other MCP client):**
+    When configuring this MCP server (e.g., in VS Code `settings.json`), ensure you point to the local `cli.js` file within your cloned and built repository.
+
+    Example VS Code `settings.json` configuration:
+    ```json
+    {
+        // ... other settings ...
+        "mcp": {
+            "servers": {
+                // ... other mcp servers ...
+                "playwright": {
+                    "command": "npx",
+                    "args": [
+                        "[path_to_your_cloned_repo]/playwright-mcp/cli.js"
+                        // Add any other necessary arguments here, e.g., --port, --browser
+                    ]
+                }
+            }
+        }
+        // ... other settings ...
+    }
+    ```
+    Replace `[path_to_your_cloned_repo]` with the absolute path to where you cloned the `playwright-mcp` repository. For example, if you cloned it into `/Users/yourname/projects/`, the path would be `/Users/yourname/projects/playwright-mcp/cli.js`.
+
+## Notes and Considerations
+
+*   The following security-related documents have been created:
+    *   **DEPENDENCIES.md** - Documents the dependency management and update policy
+    *   **SECURITY-FEATURES.md** - Documents the security features and best practices
+*   The `SECURITY.md` file has been updated to include supported versions information.
+*   No critical security issues were identified during this review.
+
+---
+*This document is subject to updates upon new reviews or significant changes to the repository.*

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,14 @@
+# Dependency Management Policy
+
+This document outlines our approach to managing dependencies in the playwright-mcp project.
+
+## Dependency Update Process
+
+1. **Regular Audits**: Dependencies are audited upon supported version changes using `npm audit` to identify any security vulnerabilities.
+2. **Update Schedule**: Security updates will be applied immediately, other updates are upon request.
+3. **Version Pinning**: All dependencies are pinned to specific versions to ensure reproducible builds.
+5. **Monitoring**: We use GitHub's dependabot alerts to monitor for security vulnerabilities in our dependencies.
+
+## Reporting Issues
+
+If you discover a security vulnerability in one of our dependencies, please follow the security reporting guidelines in our [SECURITY.md](./SECURITY.md) file.

--- a/SECURITY-FEATURES.md
+++ b/SECURITY-FEATURES.md
@@ -1,0 +1,41 @@
+# Playwright MCP Security Features
+
+This document outlines the security features and considerations for the playwright-mcp project.
+
+## Security Features
+
+1. **Input Validation and Sanitization**:
+   - All user inputs are validated using Zod schemas
+   - Proper sanitization of file paths and other potentially dangerous inputs
+   - Input validation present in config parsing
+
+2. **Error Handling**:
+   - Secure error handling practices
+   - No sensitive information is exposed in error messages or logs
+
+3. **Secure Architecture**:
+   - Uses the Model Context Protocol (MCP) for structured communication
+   - Avoids direct command execution from user inputs
+   - No hardcoded secrets or credentials in the codebase
+
+4. **Browser Security**:
+   - Option to run in isolated browser contexts
+   - Support for HTTPS error handling
+   - Clean session management
+
+## Best Practices for Secure Usage
+
+1. **Always use the latest version** to ensure you have the most recent security patches.
+
+2. **Run with minimal privileges** when possible.
+
+3. **Configure proper timeouts** to prevent resource exhaustion attacks.
+
+4. **Validate URLs** before navigating to them to prevent navigation to malicious sites.
+
+5. **Use proper error handling** in your implementations to catch and handle exceptions securely.
+
+## Additional Resources
+
+- [SECURITY.md](./SECURITY.md) - Our security policy and vulnerability reporting process
+- [DEPENDENCIES.md](./DEPENDENCIES.md) - Our dependency management and update policy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Instead, please report them to the Microsoft Security Response Center (MSRC) at 
 
 If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
@@ -37,5 +37,14 @@ We prefer all communications to be in English.
 ## Policy
 
 Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
+
+## Supported Versions
+
+| Version | Supported            |
+| ------- | ------------------   |
+| 0.0.27  | *active development* |
+| < 0.0.27| :x:                  |
+
+We recommend using the most recent version of playwright-mcp for the best security and performance. Security updates will only be applied to the latest version.
 
 <!-- END MICROSOFT SECURITY.MD BLOCK -->


### PR DESCRIPTION
Note the idea is to have a standard `CHATHAM.md` file that establishes an approval process for a Chatham-maintained MCP or Chatham-hosted fork of an opensource MCP, and documents installation instructions. Pulling these and running locally instead of from public images or package managers protects Chatham developers from accidentally using compromised MCPs.